### PR TITLE
Add feature Reconnect - Enhanced auth flows

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,6 +72,10 @@ type Client interface {
 	// it will attempt to connect at v3.1.1 and auto retry at v3.1 if that
 	// fails
 	Connect() Token
+	// Reconnect will refresh a connection to the message broker
+	// trying to keep subscriptions active
+	// It allows to update client options
+	Reconnect(o *ClientOptions)
 	// Disconnect will end the connection with the server, but not before waiting
 	// the specified number of milliseconds to wait for existing work to be
 	// completed.
@@ -298,6 +302,21 @@ func (c *client) Connect() Token {
 		DEBUG.Println(CLI, "exit startClient")
 	}()
 	return t
+}
+
+// Reconnect will refresh a connection to the message broker
+// trying to keep subscriptions active (no tangible side effects)
+// It allows to update client options if needed
+// Note: client options update can be useful for enhanced security
+// flows such as credential rotation, refresh tokens, etc.
+func (c *client) Reconnect(options *ClientOptions) {
+	c.options = *options
+	c.reconnect(func(success bool) error {
+		if !success {
+			return fmt.Errorf("Reconnect failure")
+		}
+		return nil
+	})
 }
 
 // internal function used to reconnect the client when it loses its connection


### PR DESCRIPTION
# Use cases

In the current implementation (`master`) it is not possible to use the client `reconnect` function since it is private. Moreover it is not possible to update `ClientOptions` on reconnection.

Therefore the library cannot be used with enhanced auth flows where credentials rotation/token refresh is needed without closing existing sessions/subscriptions.

# Change log

* add `Reconnect` function on `Client` interface
* add `ClientOptions` update on Reconnect