### PR TITLE
Optimize TCP connection logic

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -50,16 +50,7 @@ func openConnection(uri *url.URL, tlsc *tls.Config, timeout time.Duration, heade
 		conn, err := NewWebsocket(dialURI.String(), tlsc, timeout, headers, websocketOptions)
 		return conn, err
 	case "mqtt", "tcp":
-		allProxy := os.Getenv("all_proxy")
-		if len(allProxy) == 0 {
-			conn, err := dialer.Dial("tcp", uri.Host)
-			if err != nil {
-				return nil, err
-			}
-			return conn, nil
-		}
-		proxyDialer := proxy.FromEnvironment()
-
+		proxyDialer := proxy.FromEnvironmentUsing(dialer)
 		conn, err := proxyDialer.Dial("tcp", uri.Host)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Optimize TCP connection logic, use proxy settings in the environment instead of the original all_proxy environment variable check
Supports both ALL_PROXY and all_proxy environment variables