### PR TITLE
Fields over 65535 bytes not encoded correctly

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -330,6 +330,11 @@ func decodeBytes(b io.Reader) ([]byte, error) {
 }
 
 func encodeBytes(field []byte) []byte {
+	// Attempting to encode more than 65,535 bytes would lead to an unexpected 16-bit length and extra data written
+	// (which would be parsed as later parts of the message). The safest option is to truncate.
+	if len(field) > 65535 {
+		field = field[0:65535]
+	}
 	fieldLength := make([]byte, 2)
 	binary.BigEndian.PutUint16(fieldLength, uint16(len(field)))
 	return append(fieldLength, field...)

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -250,4 +250,13 @@ func TestEncoding(t *testing.T) {
 			t.Errorf("encodeLength(%d) did not return [0x%X], but [0x%X]", length, encoded, res)
 		}
 	}
+
+	// When encoding a string longer than 2^16 bytes, the result must not exceed the length of the 16 bit header
+	// (previously this was possible due to the use of uint16(len(field)) for the length and then writing the entirety of
+	// field.
+	overlengthStr := bytes.Repeat([]byte("A"), 65600)         // longer than 2^16
+	if res := encodeBytes(overlengthStr); len(res) != 65537 { // Two byte length so 65535 + 2 = 65537
+		t.Errorf("encodeBytes did not truncate overlength data (expected len 65538, received %d", len(res))
+	}
+
 }


### PR DESCRIPTION
When encoding strings (1.5.3 in spec), and some other variable length fields, if the user passed in more then 65535 bytes the ouput would not be as expected (due to 16 byte header there is a hard limit). 

This change truncates output to 65535 bytes.