### PR TITLE
Add a ConnectionNotificationHandler

### DIFF
--- a/client.go
+++ b/client.go
@@ -382,7 +382,7 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 			tlsCfg = c.options.OnConnectAttempt(broker, c.options.TLSConfig)
 		}
 		if c.options.OnConnectionNotification != nil {
-			c.options.OnConnectionNotification(c, ConnectionNotificationAttempt{broker})
+			c.options.OnConnectionNotification(c, ConnectionNotificationBroker{broker})
 		}
 		connDeadline := time.Now().Add(c.options.ConnectTimeout) // Time by which connection must be established
 		dialer := c.options.Dialer
@@ -401,7 +401,7 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 			WARN.Println(CLI, "failed to connect to broker, trying next")
 			rc = packets.ErrNetworkError
 			if c.options.OnConnectionNotification != nil {
-				c.options.OnConnectionNotification(c, ConnectionNotificationAttemptFailed{broker, err})
+				c.options.OnConnectionNotification(c, ConnectionNotificationBrokerFailed{broker, err})
 			}
 			continue
 		}

--- a/client.go
+++ b/client.go
@@ -318,12 +318,12 @@ func (c *client) reconnect(connectionUp connCompletedFn) {
 		DEBUG.Println(CLI, "Detect continual connection lost after reconnect, slept for", int(slp.Seconds()), "seconds")
 	}
 
-	var err error
 	var attemptCount int
 	for {
 		if nil != c.options.OnReconnecting {
 			c.options.OnReconnecting(c, &c.options)
 		}
+		var err error
 		conn, _, _, err = c.attemptConnection(true, attemptCount)
 		if err == nil {
 			break

--- a/cmd/simple/main.go
+++ b/cmd/simple/main.go
@@ -39,6 +39,22 @@ func main() {
 	opts.SetKeepAlive(2 * time.Second)
 	opts.SetDefaultPublishHandler(f)
 	opts.SetPingTimeout(1 * time.Second)
+	opts.SetConnectionNotificationHandler(func(client mqtt.Client, notification mqtt.ConnectionNotification) {
+		switch n := notification.(type) {
+		case mqtt.ConnectionNotificationConnected:
+			fmt.Printf("[NOTIFICATION] connected\n")
+		case mqtt.ConnectionNotificationConnecting:
+			fmt.Printf("[NOTIFICATION] connecting (isReconnect=%t) [%d]\n", n.IsReconnect, n.Attempt)
+		case mqtt.ConnectionNotificationFailed:
+			fmt.Printf("[NOTIFICATION] connection failed: %v\n", n.Reason)
+		case mqtt.ConnectionNotificationLost:
+			fmt.Printf("[NOTIFICATION] connection lost: %v\n", n.Reason)
+		case mqtt.ConnectionNotificationBroker:
+			fmt.Printf("[NOTIFICATION] broker connection: %s\n", n.Broker.String())
+		case mqtt.ConnectionNotificationBrokerFailed:
+			fmt.Printf("[NOTIFICATION] broker connection failed: %v [%s]\n", n.Reason, n.Broker.String())
+		}
+	})
 
 	c := mqtt.NewClient(opts)
 	if token := c.Connect(); token.Wait() && token.Error() != nil {

--- a/connnotf.go
+++ b/connnotf.go
@@ -7,12 +7,11 @@ type ConnectionNotificationType int64
 const (
 	ConnectionNotificationTypeUndefined ConnectionNotificationType = iota
 	ConnectionNotificationTypeConnected
+	ConnectionNotificationTypeConnecting
 	ConnectionNotificationTypeFailed
 	ConnectionNotificationTypeLost
-	ConnectionNotificationTypeReconnecting
 	ConnectionNotificationTypeAttempt
 	ConnectionNotificationTypeAttemptFailed
-	ConnectionNotificationTypeRetry
 )
 
 type ConnectionNotification interface {
@@ -26,6 +25,17 @@ type ConnectionNotificationConnected struct {
 
 func (n ConnectionNotificationConnected) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeConnected
+}
+
+// Connecting
+
+type ConnectionNotificationConnecting struct {
+	IsReconnect bool
+	Attempt     int
+}
+
+func (n ConnectionNotificationConnecting) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeConnecting
 }
 
 // ConnectionFailed
@@ -48,16 +58,6 @@ func (n ConnectionNotificationLost) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeLost
 }
 
-// Reconnecting
-
-type ConnectionNotificationReconnecting struct {
-	Reason error // may be nil
-}
-
-func (n ConnectionNotificationReconnecting) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeReconnecting
-}
-
 // ConnectionAttempt
 
 type ConnectionNotificationAttempt struct {
@@ -77,15 +77,4 @@ type ConnectionNotificationAttemptFailed struct {
 
 func (n ConnectionNotificationAttemptFailed) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeAttemptFailed
-}
-
-// Connected
-
-type ConnectionNotificationRetry struct {
-	Count  int
-	Reason error
-}
-
-func (n ConnectionNotificationRetry) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeRetry
 }

--- a/connnotf.go
+++ b/connnotf.go
@@ -5,8 +5,7 @@ import "net/url"
 type ConnectionNotificationType int64
 
 const (
-	ConnectionNotificationTypeUndefined ConnectionNotificationType = iota
-	ConnectionNotificationTypeConnected
+	ConnectionNotificationTypeConnected ConnectionNotificationType = iota
 	ConnectionNotificationTypeConnecting
 	ConnectionNotificationTypeFailed
 	ConnectionNotificationTypeLost
@@ -38,7 +37,7 @@ func (n ConnectionNotificationConnecting) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeConnecting
 }
 
-// ConnectionFailed
+// Connection Failed
 
 type ConnectionNotificationFailed struct {
 	Reason error
@@ -48,7 +47,7 @@ func (n ConnectionNotificationFailed) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeFailed
 }
 
-// ConnectionLost
+// Connection Lost
 
 type ConnectionNotificationLost struct {
 	Reason error // may be nil
@@ -58,7 +57,7 @@ func (n ConnectionNotificationLost) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeLost
 }
 
-// ConnectionAttempt
+// Connection Attempt
 
 type ConnectionNotificationAttempt struct {
 	Broker *url.URL
@@ -68,7 +67,7 @@ func (n ConnectionNotificationAttempt) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeAttempt
 }
 
-// ConnectionAttemptFailed
+// Connection Attempt Failed
 
 type ConnectionNotificationAttemptFailed struct {
 	Broker *url.URL

--- a/connnotf.go
+++ b/connnotf.go
@@ -9,8 +9,8 @@ const (
 	ConnectionNotificationTypeConnecting
 	ConnectionNotificationTypeFailed
 	ConnectionNotificationTypeLost
-	ConnectionNotificationTypeAttempt
-	ConnectionNotificationTypeAttemptFailed
+	ConnectionNotificationTypeBroker
+	ConnectionNotificationTypeBrokerFailed
 )
 
 type ConnectionNotification interface {
@@ -57,23 +57,23 @@ func (n ConnectionNotificationLost) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeLost
 }
 
-// Connection Attempt
+// Broker Connection
 
-type ConnectionNotificationAttempt struct {
+type ConnectionNotificationBroker struct {
 	Broker *url.URL
 }
 
-func (n ConnectionNotificationAttempt) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeAttempt
+func (n ConnectionNotificationBroker) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeBroker
 }
 
-// Connection Attempt Failed
+// Broker Connection Failed
 
-type ConnectionNotificationAttemptFailed struct {
+type ConnectionNotificationBrokerFailed struct {
 	Broker *url.URL
 	Reason error
 }
 
-func (n ConnectionNotificationAttemptFailed) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeAttemptFailed
+func (n ConnectionNotificationBrokerFailed) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeBrokerFailed
 }

--- a/connnotf.go
+++ b/connnotf.go
@@ -1,0 +1,73 @@
+package mqtt
+
+import "net/url"
+
+type ConnectionNotificationType int64
+
+const (
+	ConnectionNotificationTypeUndefined ConnectionNotificationType = iota
+	ConnectionNotificationTypeConnected
+	ConnectionNotificationTypeConnectionLost
+	ConnectionNotificationTypeReconnecting
+	ConnectionNotificationTypeConnectionAttempt
+	ConnectionNotificationTypeConnectionAttemptFailed
+	// ConnectionNotificationTypeConnectionRetry
+	// ConnectionNotificationTypeConnectionRetryFailed
+)
+
+type ConnectionNotification interface {
+	Type() ConnectionNotificationType
+}
+
+// Connected
+
+type ConnectionNotificationConnected struct {
+	Client Client
+}
+
+func (n ConnectionNotificationConnected) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeConnected
+}
+
+// ConnectionLost
+
+type ConnectionNotificationConnectionLost struct {
+	Client Client
+	Reason error // may be nil
+}
+
+func (n ConnectionNotificationConnectionLost) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeConnectionLost
+}
+
+// Reconnecting
+
+type ConnectionNotificationReconnecting struct {
+	Client Client
+	Reason error // may be nil
+}
+
+func (n ConnectionNotificationReconnecting) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeReconnecting
+}
+
+// ConnectionAttempt
+
+type ConnectionNotificationConnectionAttempt struct {
+	Broker *url.URL
+}
+
+func (n ConnectionNotificationConnectionAttempt) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeConnectionAttempt
+}
+
+// ConnectionAttemptFailed
+
+type ConnectionNotificationConnectionAttemptFailed struct {
+	Broker *url.URL
+	Reason error
+}
+
+func (n ConnectionNotificationConnectionAttemptFailed) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeConnectionAttemptFailed
+}

--- a/connnotf.go
+++ b/connnotf.go
@@ -7,12 +7,12 @@ type ConnectionNotificationType int64
 const (
 	ConnectionNotificationTypeUndefined ConnectionNotificationType = iota
 	ConnectionNotificationTypeConnected
-	ConnectionNotificationTypeConnectionLost
+	ConnectionNotificationTypeFailed
+	ConnectionNotificationTypeLost
 	ConnectionNotificationTypeReconnecting
-	ConnectionNotificationTypeConnectionAttempt
-	ConnectionNotificationTypeConnectionAttemptFailed
-	// ConnectionNotificationTypeConnectionRetry
-	// ConnectionNotificationTypeConnectionRetryFailed
+	ConnectionNotificationTypeAttempt
+	ConnectionNotificationTypeAttemptFailed
+	ConnectionNotificationTypeRetry
 )
 
 type ConnectionNotification interface {
@@ -22,28 +22,35 @@ type ConnectionNotification interface {
 // Connected
 
 type ConnectionNotificationConnected struct {
-	Client Client
 }
 
 func (n ConnectionNotificationConnected) Type() ConnectionNotificationType {
 	return ConnectionNotificationTypeConnected
 }
 
+// ConnectionFailed
+
+type ConnectionNotificationFailed struct {
+	Reason error
+}
+
+func (n ConnectionNotificationFailed) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeFailed
+}
+
 // ConnectionLost
 
-type ConnectionNotificationConnectionLost struct {
-	Client Client
+type ConnectionNotificationLost struct {
 	Reason error // may be nil
 }
 
-func (n ConnectionNotificationConnectionLost) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeConnectionLost
+func (n ConnectionNotificationLost) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeLost
 }
 
 // Reconnecting
 
 type ConnectionNotificationReconnecting struct {
-	Client Client
 	Reason error // may be nil
 }
 
@@ -53,21 +60,32 @@ func (n ConnectionNotificationReconnecting) Type() ConnectionNotificationType {
 
 // ConnectionAttempt
 
-type ConnectionNotificationConnectionAttempt struct {
+type ConnectionNotificationAttempt struct {
 	Broker *url.URL
 }
 
-func (n ConnectionNotificationConnectionAttempt) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeConnectionAttempt
+func (n ConnectionNotificationAttempt) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeAttempt
 }
 
 // ConnectionAttemptFailed
 
-type ConnectionNotificationConnectionAttemptFailed struct {
+type ConnectionNotificationAttemptFailed struct {
 	Broker *url.URL
 	Reason error
 }
 
-func (n ConnectionNotificationConnectionAttemptFailed) Type() ConnectionNotificationType {
-	return ConnectionNotificationTypeConnectionAttemptFailed
+func (n ConnectionNotificationAttemptFailed) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeAttemptFailed
+}
+
+// Connected
+
+type ConnectionNotificationRetry struct {
+	Count  int
+	Reason error
+}
+
+func (n ConnectionNotificationRetry) Type() ConnectionNotificationType {
+	return ConnectionNotificationTypeRetry
 }

--- a/options.go
+++ b/options.go
@@ -62,93 +62,99 @@ type ConnectionAttemptHandler func(broker *url.URL, tlsCfg *tls.Config) *tls.Con
 // Does not carry out any MQTT specific handshakes.
 type OpenConnectionFunc func(uri *url.URL, options ClientOptions) (net.Conn, error)
 
+// ConnectionNotificationHandler is invoked for any type of connection event.
+type ConnectionNotificationHandler func(notification ConnectionNotification)
+
 // ClientOptions contains configurable options for an Client. Note that these should be set using the
 // relevant methods (e.g. AddBroker) rather than directly. See those functions for information on usage.
 // WARNING: Create the below using NewClientOptions unless you have a compelling reason not to. It is easy
 // to create a configuration with difficult to trace issues (e.g. Mosquitto 2.0.12+ will reject connections
 // with KeepAlive=0 by default).
 type ClientOptions struct {
-	Servers                 []*url.URL
-	ClientID                string
-	Username                string
-	Password                string
-	CredentialsProvider     CredentialsProvider
-	CleanSession            bool
-	Order                   bool
-	WillEnabled             bool
-	WillTopic               string
-	WillPayload             []byte
-	WillQos                 byte
-	WillRetained            bool
-	ProtocolVersion         uint
-	protocolVersionExplicit bool
-	TLSConfig               *tls.Config
-	KeepAlive               int64 // Warning: Some brokers may reject connections with Keepalive = 0.
-	PingTimeout             time.Duration
-	ConnectTimeout          time.Duration
-	MaxReconnectInterval    time.Duration
-	AutoReconnect           bool
-	ConnectRetryInterval    time.Duration
-	ConnectRetry            bool
-	Store                   Store
-	DefaultPublishHandler   MessageHandler
-	OnConnect               OnConnectHandler
-	OnConnectionLost        ConnectionLostHandler
-	OnReconnecting          ReconnectHandler
-	OnConnectAttempt        ConnectionAttemptHandler
-	WriteTimeout            time.Duration
-	MessageChannelDepth     uint
-	ResumeSubs              bool
-	HTTPHeaders             http.Header
-	WebsocketOptions        *WebsocketOptions
-	MaxResumePubInFlight    int // // 0 = no limit; otherwise this is the maximum simultaneous messages sent while resuming
-	Dialer                  *net.Dialer
-	CustomOpenConnectionFn  OpenConnectionFunc
-	AutoAckDisabled         bool
+	Servers                  []*url.URL
+	ClientID                 string
+	Username                 string
+	Password                 string
+	CredentialsProvider      CredentialsProvider
+	CleanSession             bool
+	Order                    bool
+	WillEnabled              bool
+	WillTopic                string
+	WillPayload              []byte
+	WillQos                  byte
+	WillRetained             bool
+	ProtocolVersion          uint
+	protocolVersionExplicit  bool
+	TLSConfig                *tls.Config
+	KeepAlive                int64 // Warning: Some brokers may reject connections with Keepalive = 0.
+	PingTimeout              time.Duration
+	ConnectTimeout           time.Duration
+	MaxReconnectInterval     time.Duration
+	AutoReconnect            bool
+	ConnectRetryInterval     time.Duration
+	ConnectRetry             bool
+	Store                    Store
+	DefaultPublishHandler    MessageHandler
+	OnConnect                OnConnectHandler
+	OnConnectionLost         ConnectionLostHandler
+	OnReconnecting           ReconnectHandler
+	OnConnectAttempt         ConnectionAttemptHandler
+	OnConnectionNotification ConnectionNotificationHandler
+	WriteTimeout             time.Duration
+	MessageChannelDepth      uint
+	ResumeSubs               bool
+	HTTPHeaders              http.Header
+	WebsocketOptions         *WebsocketOptions
+	MaxResumePubInFlight     int // // 0 = no limit; otherwise this is the maximum simultaneous messages sent while resuming
+	Dialer                   *net.Dialer
+	CustomOpenConnectionFn   OpenConnectionFunc
+	AutoAckDisabled          bool
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
 // default values.
-//   Port: 1883
-//   CleanSession: True
-//   Order: True (note: it is recommended that this be set to FALSE unless order is important)
-//   KeepAlive: 30 (seconds)
-//   ConnectTimeout: 30 (seconds)
-//   MaxReconnectInterval 10 (minutes)
-//   AutoReconnect: True
+//
+//	Port: 1883
+//	CleanSession: True
+//	Order: True (note: it is recommended that this be set to FALSE unless order is important)
+//	KeepAlive: 30 (seconds)
+//	ConnectTimeout: 30 (seconds)
+//	MaxReconnectInterval 10 (minutes)
+//	AutoReconnect: True
 func NewClientOptions() *ClientOptions {
 	o := &ClientOptions{
-		Servers:                 nil,
-		ClientID:                "",
-		Username:                "",
-		Password:                "",
-		CleanSession:            true,
-		Order:                   true,
-		WillEnabled:             false,
-		WillTopic:               "",
-		WillPayload:             nil,
-		WillQos:                 0,
-		WillRetained:            false,
-		ProtocolVersion:         0,
-		protocolVersionExplicit: false,
-		KeepAlive:               30,
-		PingTimeout:             10 * time.Second,
-		ConnectTimeout:          30 * time.Second,
-		MaxReconnectInterval:    10 * time.Minute,
-		AutoReconnect:           true,
-		ConnectRetryInterval:    30 * time.Second,
-		ConnectRetry:            false,
-		Store:                   nil,
-		OnConnect:               nil,
-		OnConnectionLost:        DefaultConnectionLostHandler,
-		OnConnectAttempt:        nil,
-		WriteTimeout:            0, // 0 represents timeout disabled
-		ResumeSubs:              false,
-		HTTPHeaders:             make(map[string][]string),
-		WebsocketOptions:        &WebsocketOptions{},
-		Dialer:                  &net.Dialer{Timeout: 30 * time.Second},
-		CustomOpenConnectionFn:  nil,
-		AutoAckDisabled:         false,
+		Servers:                  nil,
+		ClientID:                 "",
+		Username:                 "",
+		Password:                 "",
+		CleanSession:             true,
+		Order:                    true,
+		WillEnabled:              false,
+		WillTopic:                "",
+		WillPayload:              nil,
+		WillQos:                  0,
+		WillRetained:             false,
+		ProtocolVersion:          0,
+		protocolVersionExplicit:  false,
+		KeepAlive:                30,
+		PingTimeout:              10 * time.Second,
+		ConnectTimeout:           30 * time.Second,
+		MaxReconnectInterval:     10 * time.Minute,
+		AutoReconnect:            true,
+		ConnectRetryInterval:     30 * time.Second,
+		ConnectRetry:             false,
+		Store:                    nil,
+		OnConnect:                nil,
+		OnConnectionLost:         DefaultConnectionLostHandler,
+		OnConnectAttempt:         nil,
+		OnConnectionNotification: nil,
+		WriteTimeout:             0, // 0 represents timeout disabled
+		ResumeSubs:               false,
+		HTTPHeaders:              make(map[string][]string),
+		WebsocketOptions:         &WebsocketOptions{},
+		Dialer:                   &net.Dialer{Timeout: 30 * time.Second},
+		CustomOpenConnectionFn:   nil,
+		AutoAckDisabled:          false,
 	}
 	return o
 }
@@ -355,6 +361,13 @@ func (o *ClientOptions) SetConnectionAttemptHandler(onConnectAttempt ConnectionA
 	return o
 }
 
+// SetConnectionNotificationHandler sets the ConnectionNotificationHandler callback to receive all types of connection
+// events.
+func (o *ClientOptions) SetConnectionNotificationHandler(onConnectionNotification ConnectionNotificationHandler) *ClientOptions {
+	o.OnConnectionNotification = onConnectionNotification
+	return o
+}
+
 // SetWriteTimeout puts a limit on how long a mqtt publish should block until it unblocks with a
 // timeout error. A duration of 0 never times out. Default never times out
 func (o *ClientOptions) SetWriteTimeout(t time.Duration) *ClientOptions {
@@ -450,6 +463,7 @@ func (o *ClientOptions) SetCustomOpenConnectionFn(customOpenConnectionFn OpenCon
 }
 
 // SetAutoAckDisabled enables or disables the Automated Acking of Messages received by the handler.
+//
 //	By default it is set to false. Setting it to true will disable the auto-ack globally.
 func (o *ClientOptions) SetAutoAckDisabled(autoAckDisabled bool) *ClientOptions {
 	o.AutoAckDisabled = autoAckDisabled

--- a/options.go
+++ b/options.go
@@ -63,7 +63,7 @@ type ConnectionAttemptHandler func(broker *url.URL, tlsCfg *tls.Config) *tls.Con
 type OpenConnectionFunc func(uri *url.URL, options ClientOptions) (net.Conn, error)
 
 // ConnectionNotificationHandler is invoked for any type of connection event.
-type ConnectionNotificationHandler func(notification ConnectionNotification)
+type ConnectionNotificationHandler func(Client, ConnectionNotification)
 
 // ClientOptions contains configurable options for an Client. Note that these should be set using the
 // relevant methods (e.g. AddBroker) rather than directly. See those functions for information on usage.


### PR DESCRIPTION
Following [this issue comment](https://github.com/eclipse-paho/paho.mqtt.golang/issues/579#issuecomment-1015989968), I implemented a generic callback for all types of connection events.

Fixes #579 

```
[NOTIFICATION] connecting (isReconnect=false) [0]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] broker connection failed: dial tcp 127.0.0.1:1883: connect: connection refused [tcp://127.0.0.1:1883]
[NOTIFICATION] connection failed: network Error : dial tcp 127.0.0.1:1883: connect: connection refused
[NOTIFICATION] connecting (isReconnect=false) [1]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] broker connection failed: dial tcp 127.0.0.1:1883: connect: connection refused [tcp://127.0.0.1:1883]
[NOTIFICATION] connection failed: network Error : dial tcp 127.0.0.1:1883: connect: connection refused
[NOTIFICATION] connecting (isReconnect=false) [2]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] connected
TOPIC: go-mqtt/sample
MSG: this is msg #0!
TOPIC: go-mqtt/sample
MSG: this is msg #1!
TOPIC: go-mqtt/sample
MSG: this is msg #2!
TOPIC: go-mqtt/sample
MSG: this is msg #3!
TOPIC: go-mqtt/sample
MSG: this is msg #4!
[NOTIFICATION] connecting (isReconnect=true) [0]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] connection lost: EOF
[NOTIFICATION] broker connection failed: dial tcp 127.0.0.1:1883: connect: connection refused [tcp://127.0.0.1:1883]
[NOTIFICATION] connection failed: network Error : dial tcp 127.0.0.1:1883: connect: connection refused
[NOTIFICATION] connecting (isReconnect=true) [1]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] broker connection failed: dial tcp 127.0.0.1:1883: connect: connection refused [tcp://127.0.0.1:1883]
[NOTIFICATION] connection failed: network Error : dial tcp 127.0.0.1:1883: connect: connection refused
[NOTIFICATION] connecting (isReconnect=true) [2]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] broker connection failed: dial tcp 127.0.0.1:1883: connect: connection refused [tcp://127.0.0.1:1883]
[NOTIFICATION] connection failed: network Error : dial tcp 127.0.0.1:1883: connect: connection refused
[NOTIFICATION] connecting (isReconnect=true) [3]
[NOTIFICATION] broker connection: tcp://127.0.0.1:1883
[NOTIFICATION] connected
```